### PR TITLE
Fix: Improve UUID generation method in ListItemComponent

### DIFF
--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jh1777/jh-ui",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "A library of handmade Angular UI components.",
   "keywords": [
     "angular",

--- a/projects/ui/src/lib/components/list/list-item/list-item.component.ts
+++ b/projects/ui/src/lib/components/list/list-item/list-item.component.ts
@@ -44,10 +44,32 @@ export class ListItemComponent extends UIBaseComponent implements AfterContentIn
   isHovered = signal<boolean>(false);
 
   description = input<string>();
+
+  private createUuid(): string {
+    const cryptoApi = globalThis.crypto;
+
+    if (cryptoApi?.randomUUID) {
+      return cryptoApi.randomUUID();
+    }
+
+    if (cryptoApi?.getRandomValues) {
+      const bytes = new Uint8Array(16);
+      cryptoApi.getRandomValues(bytes);
+
+      // RFC4122 version 4 UUID bits.
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+      const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0'));
+      return `${hex[0]}${hex[1]}${hex[2]}${hex[3]}-${hex[4]}${hex[5]}-${hex[6]}${hex[7]}-${hex[8]}${hex[9]}-${hex[10]}${hex[11]}${hex[12]}${hex[13]}${hex[14]}${hex[15]}`;
+    }
+
+    return `ui-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }
   
   constructor() {
     super();
-    const uuid = crypto.randomUUID();
+    const uuid = this.createUuid();
     effect(() => {
       if (!this.id()) {
         this.uuid = uuid;


### PR DESCRIPTION
This pull request refactors the UUID generation logic in the `ListItemComponent` to improve compatibility and reliability. The main change is replacing direct usage of `crypto.randomUUID()` with a new `createUuid()` method that gracefully falls back to alternative approaches if `randomUUID` is unavailable.

UUID generation improvements:

* Added a private `createUuid()` method to `ListItemComponent` that first attempts to use `crypto.randomUUID`, then falls back to a manual RFC4122-compliant UUID generation using `crypto.getRandomValues`, and finally falls back to a timestamp and random string if neither API is available. (`projects/ui/src/lib/components/list/list-item/list-item.component.ts`, [projects/ui/src/lib/components/list/list-item/list-item.component.tsR48-R72](diffhunk://#diff-4c0c94baf7700bbb2a4a85846145ece59ee370d92be3a4d0485961b03bc1c713R48-R72))
* Updated the constructor to use `this.createUuid()` instead of directly calling `crypto.randomUUID()`, ensuring robust UUID assignment across different environments. (`projects/ui/src/lib/components/list/list-item/list-item.component.ts`, [projects/ui/src/lib/components/list/list-item/list-item.component.tsR48-R72](diffhunk://#diff-4c0c94baf7700bbb2a4a85846145ece59ee370d92be3a4d0485961b03bc1c713R48-R72))